### PR TITLE
fix null deference when dns.Msg is nil

### DIFF
--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -71,7 +71,7 @@ func (c *Cache) EvictRandom() {
 // InsertMessage inserts a message in the Cache. We will cache it for ttl seconds, which
 // should be a small (60...300) integer.
 func (c *Cache) InsertMessage(s string, m *dns.Msg) {
-	if c.capacity <= 0 || len(m.Answer) == 0 {
+	if c.capacity <= 0 || m == nil || len(m.Answer) == 0 {
 		return
 	}
 


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x511a38]

goroutine 24 [running]:
panic(0x668be0, 0xc4200140c0)
	/usr/lib/go-1.7/src/runtime/panic.go:500 +0x1a1
github.com/shawn1m/overture/core/cache.(*Cache).InsertMessage(0xc42000d200, 0xc4200b3a80, 0x1d, 0x0)
	/root/go/src/github.com/shawn1m/overture/core/cache/cache.go:74 +0x58
github.com/shawn1m/overture/core/outbound.(*ClientBundle).CacheResults(0xc420070f60)
	/root/go/src/github.com/shawn1m/overture/core/outbound/clientbundle.go:97 +0xc7
github.com/shawn1m/overture/core/outbound.(*Dispatcher).Exchange(0xc420094100)
	/root/go/src/github.com/shawn1m/overture/core/outbound/dispatcher.go:42 +0xed
github.com/shawn1m/overture/core/inbound.(*Server).ServeDNS(0xc42001a690, 0x7c0980, 0xc420094480, 0xc42008c750)
	/root/go/src/github.com/shawn1m/overture/core/inbound/server.go:65 +0x21e
github.com/miekg/dns.(*ServeMux).ServeDNS(0xc420015340, 0x7c0980, 0xc420094480, 0xc42008c750)
	/root/go/src/github.com/miekg/dns/server.go:210 +0x61
github.com/miekg/dns.(*Server).serve(0xc4200736c0, 0x7bc3a0, 0xc4200aeae0, 0x7baaa0, 0xc420015340, 0xc4200ab600, 0x20, 0x200, 0xc420030048, 0xc4200b2300, ...)
	/root/go/src/github.com/miekg/dns/server.go:579 +0x500
created by github.com/miekg/dns.(*Server).serveUDP
	/root/go/src/github.com/miekg/dns/server.go:533 +0x2d7
exit status 2