### PR TITLE
use configurated external ip over client ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ IPv6). Overture will handle both TCP and UDP requests. Literal IPv6 addresses ar
     + EDNSClientSubnet: Used to improve DNS accuracy. Please check [RFC7871](https://tools.ietf.org/html/rfc7871) for
     details.
         + Policy
-            + `auto`: If client IP is not in the reserved IP network, use client IP. Otherwise, use external IP.
+            + `auto`: Use external IP if this field is not empty, otherwise use client IP if it is not reserved IP.
             + `disable`: Disable this feature.
         + ExternalIP: If this field is empty, ECS will be disabled when the inbound IP is not an external IP.
 + OnlyPrimaryDNS: Disable dispatcher feature, use primary DNS only.

--- a/core/outbound/client.go
+++ b/core/outbound/client.go
@@ -38,10 +38,13 @@ func (c *Client) getEDNSClientSubnetIP() {
 
 	switch c.DNSUpstream.EDNSClientSubnet.Policy {
 	case "auto":
+		if c.DNSUpstream.EDNSClientSubnet.ExternalIP != "" &&
+			!common.IsIPMatchList(net.ParseIP(c.DNSUpstream.EDNSClientSubnet.ExternalIP), common.ReservedIPNetworkList, false) {
+			c.EDNSClientSubnetIP = c.DNSUpstream.EDNSClientSubnet.ExternalIP
+			return
+		}
 		if !common.IsIPMatchList(net.ParseIP(c.InboundIP), common.ReservedIPNetworkList, false) {
 			c.EDNSClientSubnetIP = c.InboundIP
-		} else {
-			c.EDNSClientSubnetIP = c.DNSUpstream.EDNSClientSubnet.ExternalIP
 		}
 	case "disable":
 	}


### PR DESCRIPTION
在某些场景下, 我们期望得到某个地区的用户的解析结果,  因此希望如果我们正确配置了该 IP 之后, 可以直接用我们自己配置的 IP. 