### PR TITLE
Feature/http dump cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Configuration file is "config.json" by default:
 ```json
 {
   "BindAddress": ":53",
+  "HTTPAddress": ":5555",
   "PrimaryDNS": [
     {
       "Name": "DNSPod",
@@ -125,6 +126,57 @@ Tips:
 
 + BindAddress: Specifying only port (e.g. `:53`) will have overture listen on all available addresses (both IPv4 and
 IPv6). Overture will handle both TCP and UDP requests. Literal IPv6 addresses are enclosed in square brackets (e.g. `[2001:4860:4860::8888]:53`)
++ HTTPAddress: Specifying an HTTP port for debugging, currently used to dump DNS cache, and the request url is `/cache`, available query argument is `nobody`(boolean)
+
+    * true(default): only get the cache size;
+
+        ```bash
+        $ curl 127.0.0.1:5555/cache | jq
+        {
+          "length": 1,
+          "capacity": 100,
+          "body": {}
+        }
+        ```
+
+    * false: get cache size along with cache detail.
+
+        ```bash
+        $ curl 127.0.0.1:5555/cache?nobody=false | jq
+        {
+          "length": 1,
+          "capacity": 100,
+          "body": {
+            "www.baidu.com. 1": [
+              {
+                "name": "www.baidu.com.",
+                "ttl": 1140,
+                "type": "CNAME",
+                "rdata": "www.a.shifen.com."
+              },
+              {
+                "name": "www.a.shifen.com.",
+                "ttl": 300,
+                "type": "CNAME",
+                "rdata": "www.wshifen.com."
+              },
+              {
+                "name": "www.wshifen.com.",
+                "ttl": 300,
+                "type": "A",
+                "rdata": "104.193.88.123"
+              },
+              {
+                "name": "www.wshifen.com.",
+                "ttl": 300,
+                "type": "A",
+                "rdata": "104.193.88.77"
+              }
+            ]
+          }
+        }
+        ```
+
 + DNS: You can specify multiple DNS upstream servers here.
     + Name: This field is only used for logging.
     + Address: Same as BindAddress.
@@ -186,10 +238,10 @@ $ dig @119.29.29.29 www.qq.com +client=119.29.29.29
 ; EDNS: version: 0, flags:; udp: 4096
 ; CLIENT-SUBNET: 119.29.29.29/32/24
 ;; QUESTION SECTION:
-;www.qq.com.			IN	A
+;www.qq.com.            IN  A
 
 ;; ANSWER SECTION:
-www.qq.com.		300	IN	A	101.226.103.106
+www.qq.com.     300 IN  A   101.226.103.106
 
 ;; Query time: 52 msec
 ;; SERVER: 119.29.29.29#53(119.29.29.29)
@@ -210,12 +262,12 @@ $ dig @119.29.29.29 www.qq.com +client=119.29.29.29 +tcp
 ;; OPT PSEUDOSECTION:
 ; EDNS: version: 0, flags:; udp: 4096
 ;; QUESTION SECTION:
-;www.qq.com.			IN	A
+;www.qq.com.            IN  A
 
 ;; ANSWER SECTION:
-www.qq.com.		43	IN	A	59.37.96.63
-www.qq.com.		43	IN	A	14.17.32.211
-www.qq.com.		43	IN	A	14.17.42.40
+www.qq.com.     43  IN  A   59.37.96.63
+www.qq.com.     43  IN  A   14.17.32.211
+www.qq.com.     43  IN  A   14.17.42.40
 
 ;; Query time: 81 msec
 ;; SERVER: 119.29.29.29#53(119.29.29.29)

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,5 +1,6 @@
 {
   "BindAddress": ":53",
+  "HTTPAddress": ":5555",
   "PrimaryDNS": [
     {
       "Name": "DNSPod",

--- a/config.test.json
+++ b/config.test.json
@@ -1,5 +1,6 @@
 {
   "BindAddress": ":53",
+  "HTTPAddress": ":5555",
   "PrimaryDNS": [
     {
       "Name": "DNSPod",

--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -11,9 +11,10 @@ import (
 	"sync"
 	"time"
 
+	"strconv"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/miekg/dns"
-	"strconv"
 )
 
 // Elem hold an answer and additional section that returned from the cache.
@@ -123,4 +124,32 @@ func (c *Cache) Hit(key string, msgid uint16) *dns.Msg {
 		c.Remove(key)
 	}
 	return nil
+}
+
+// Dump returns all dns cache information, for dubugging
+func (c *Cache) Dump(nobody bool) (rs map[string][]string, l int) {
+	if c.capacity <= 0 {
+		return
+	}
+
+	l = len(c.table)
+
+	rs = make(map[string][]string)
+
+	if nobody {
+		return
+	}
+
+	c.RLock()
+	defer c.RUnlock()
+
+	for k, e := range c.table {
+		vs := []string{}
+
+		for _, a := range e.m.Answer {
+			vs = append(vs, a.String())
+		}
+		rs[k] = vs
+	}
+	return
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -21,6 +21,7 @@ import (
 
 type Config struct {
 	BindAddress           string `json:"BindAddress"`
+	HTTPAddress           string `json:"HTTPAddress"`
 	PrimaryDNS            []*common.DNSUpstream
 	AlternativeDNS        []*common.DNSUpstream
 	OnlyPrimaryDNS        bool

--- a/core/inbound/server.go
+++ b/core/inbound/server.go
@@ -18,6 +18,7 @@ import (
 
 type Server struct {
 	BindAddress string
+	HTTPAddress string
 
 	Dispatcher outbound.Dispatcher
 
@@ -45,7 +46,7 @@ func (s *Server) DumpCache(w http.ResponseWriter, req *http.Request) {
 
 	query := req.URL.Query()
 	nobody := true
-	if t := query.Get("nobody"); t == "false" {
+	if t := query.Get("nobody"); strings.ToLower(t) == "false" {
 		nobody = false
 	}
 
@@ -103,9 +104,11 @@ func (s *Server) Run() {
 		}(p)
 	}
 
-	http.HandleFunc("/cache", s.DumpCache)
-	wg.Add(1)
-	go http.ListenAndServe(":5555", nil)
+	if s.HTTPAddress != "" {
+		http.HandleFunc("/cache", s.DumpCache)
+		wg.Add(1)
+		go http.ListenAndServe(s.HTTPAddress, nil)
+	}
 
 	wg.Wait()
 }

--- a/core/init.go
+++ b/core/init.go
@@ -35,6 +35,7 @@ func InitServer(configFilePath string) {
 
 	s := &inbound.Server{
 		BindAddress: config.BindAddress,
+		HTTPAddress: config.HTTPAddress,
 		Dispatcher:  d,
 		RejectQtype: config.RejectQtype,
 	}


### PR DESCRIPTION
Add a config of `HTTPAddress` for the debugging purpose.

HTTPAddress: Specifying an HTTP port for debugging, currently used to dump DNS cache, and the request url is `/cache`, available query argument is `nobody`(boolean)

* true(default): only get the cache size;

  ```bash
  $ curl 127.0.0.1:5555/cache | jq
  {
	"length": 1,
	"capacity": 100,
	"body": {}
  }
  ```

* false: get cache size along with cache detail.

  ```bash
  $ curl 127.0.0.1:5555/cache?nobody=false | jq
  {
	"length": 1,
	"capacity": 100,
	"body": {
	  "www.baidu.com. 1": [
		{
		  "name": "www.baidu.com.",
		  "ttl": 1140,
		  "type": "CNAME",
		  "rdata": "www.a.shifen.com."
		},
		{
		  "name": "www.a.shifen.com.",
		  "ttl": 300,
		  "type": "CNAME",
		  "rdata": "www.wshifen.com."
		},
		{
		  "name": "www.wshifen.com.",
		  "ttl": 300,
		  "type": "A",
		  "rdata": "104.193.88.123"
		},
		{
		  "name": "www.wshifen.com.",
		  "ttl": 300,
		  "type": "A",
		  "rdata": "104.193.88.77"
		}
	  ]
	}
  }
  ```


