### PR TITLE
Refactor Dispatcher for thread safe

### DIFF
--- a/config.test.json
+++ b/config.test.json
@@ -42,6 +42,6 @@
   "HostsFile": "./hosts_sample",
   "MinimumTTL": 0,
   "DomainTTLFile" : "./domain_ttl_sample",
-  "CacheSize" : 0,
+  "CacheSize" : 1,
   "RejectQType": [255]
 }

--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -56,7 +56,7 @@ func (c *Cache) Remove(s string) {
 // Must be called under a write lock.
 func (c *Cache) EvictRandom() {
 	cacheLength := len(c.table)
-	if cacheLength < c.capacity {
+	if cacheLength <= c.capacity {
 		return
 	}
 	i := c.capacity - cacheLength

--- a/core/inbound/server.go
+++ b/core/inbound/server.go
@@ -121,11 +121,7 @@ func (s *Server) Run() {
 }
 
 func (s *Server) ServeDNS(w dns.ResponseWriter, q *dns.Msg) {
-
 	inboundIP, _, _ := net.SplitHostPort(w.RemoteAddr().String())
-	currentDispatcher := s.dispatcher
-	currentDispatcher.InboundIP = inboundIP
-	currentDispatcher.QuestionMessage = q
 
 	log.Debug("Question from " + inboundIP + ": " + q.Question[0].String())
 
@@ -135,7 +131,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, q *dns.Msg) {
 		}
 	}
 
-	responseMessage := currentDispatcher.Exchange()
+	responseMessage := s.dispatcher.Exchange(q, inboundIP)
 
 	if responseMessage == nil {
 		return


### PR DESCRIPTION
Let me explain this PR. 

### Remove all changeable fields from the dispatcher during `Exchange`
The following fields are removed from the dispatcher, so dispatcher become immutable during `Exchange`

- QuestionMessage
- ResponseMessage
- PrimaryClientBundle
- AlternativeClientBundle
- ActiveClientBundle
- InboundIP

### Fix some bugs

When testing cache
https://github.com/shawn1m/overture/blob/ca111c9e5c0d58e671c66feaa05907a807aa0c08/core/outbound/dispatcher_test.go#L45
we should use non-zero cache capacity.
https://github.com/shawn1m/overture/blob/ca111c9e5c0d58e671c66feaa05907a807aa0c08/config.test.json#L45
Actually, if `cacheLength` equals capacity, we shouldn't evict anything 
https://github.com/shawn1m/overture/blob/ca111c9e5c0d58e671c66feaa05907a807aa0c08/core/cache/cache.go#L57-L61

### Optimize `selectByIPNetwork` logic
https://github.com/shawn1m/overture/blob/ca111c9e5c0d58e671c66feaa05907a807aa0c08/core/outbound/dispatcher.go#L136-L158
This part can be simplified. We can first get IP according to  the type(A or AAAA), and then determinate using primary or alternative