### PR TITLE
Return an error rather than do nothing when having no valid result

### DIFF
--- a/core/inbound/server.go
+++ b/core/inbound/server.go
@@ -134,6 +134,7 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, q *dns.Msg) {
 	responseMessage := s.dispatcher.Exchange(q, inboundIP)
 
 	if responseMessage == nil {
+		dns.HandleFailed(w, q)
 		return
 	}
 


### PR DESCRIPTION
Currently, if overture gets nothing from all of its backends, overture will not reply to the DNS query, cause the client to wait for a response.

Actually, overture should return something rather than keep the client waiting.

I'm facing this problem because many domains don't have an AAAA record. When using curl, curl wants to try ipv4 and ipv6, so curl make an AAAA query to the overture, but overture doesn't reply until timeout, cause curl to start ipv4 query very slow.

 However, dig has the same problem.

```
time dig @127.0.0.1 -p 8053 qq.com AAAA

; <<>> DiG 9.11.3-1ubuntu1.5-Ubuntu <<>> @127.0.0.1 -p 8053 qq.com AAAA
; (1 server found)
;; global options: +cmd
;; connection timed out; no servers could be reached
dig @127.0.0.1 -p 8053 qq.com AAAA  0.01s user 0.01s system 0% cpu 15.012 total
```

Dig return after 15 seconds.