### PR TITLE
Load config files directly without reading into memory first

### DIFF
--- a/core/cache/cache.go
+++ b/core/cache/cache.go
@@ -8,7 +8,7 @@ package cache
 // Cache that holds RRs.
 
 import (
-	"strconv"
+	"fmt"
 	"sync"
 	"time"
 
@@ -86,7 +86,7 @@ func (c *Cache) InsertMessage(s string, m *dns.Msg, mTTL uint32) {
 	if _, ok := c.table[s]; !ok {
 		c.table[s] = &elem{time.Now().UTC().Add(ttlDuration), m.Copy()}
 	}
-	log.Debug("Cached: " + s)
+	log.Debugf("Cached: %s", s)
 	c.EvictRandom()
 	c.Unlock()
 }
@@ -110,7 +110,7 @@ func (c *Cache) Search(s string) (*dns.Msg, time.Time, bool) {
 
 // Key creates a hash key from a question section.
 func Key(q dns.Question, ednsIP string) string {
-	return q.Name + " " + strconv.Itoa(int(q.Qtype)) + " " + ednsIP
+	return fmt.Sprintf("%s %d %s", q.Name, q.Qtype, ednsIP)
 }
 
 // Hit returns a dns message from the cache. If the message's TTL is expired nil

--- a/core/hosts/hosts.go
+++ b/core/hosts/hosts.go
@@ -6,8 +6,8 @@
 package hosts
 
 import (
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 )
 
@@ -37,12 +37,13 @@ func (h *Hosts) Find(name string) (ipv4List []net.IP, ipv6List []net.IP) {
 }
 
 func (h *Hosts) loadHostEntries() error {
-	data, err := ioutil.ReadFile(h.filePath)
+	f, err := os.Open(h.filePath)
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
-	h.hl = newHostsLineList(data)
+	h.hl = newHostsLineList(f)
 
 	return nil
 }

--- a/core/inbound/server.go
+++ b/core/inbound/server.go
@@ -106,7 +106,7 @@ func (s *Server) Run() {
 		go func(p string) {
 			err := dns.ListenAndServe(s.bindAddress, p, mux)
 			if err != nil {
-				log.Fatal("Listen "+p+" failed: ", err)
+				log.Fatalf("Listening on port %s failed: %s", p, err)
 				os.Exit(1)
 			}
 		}(p)

--- a/core/outbound/clients/remote.go
+++ b/core/outbound/clients/remote.go
@@ -99,7 +99,7 @@ func (c *RemoteClient) Exchange(isLog bool) *dns.Msg {
 				return nil
 			}
 			conf.ServerName = servername
-			c.dnsUpstream.Address = s[1] + ":" + port
+			c.dnsUpstream.Address = net.JoinHostPort(s[1], port)
 		}
 		if conn, err = tls.Dial("tcp", c.dnsUpstream.Address, conf); err != nil {
 			log.Warnf("Failed to connect to DNS-over-TLS upstream: %s", err)

--- a/core/outbound/dispatcher.go
+++ b/core/outbound/dispatcher.go
@@ -91,7 +91,7 @@ func (d *Dispatcher) isSelectDomain(rcb *clients.RemoteClientBundle, dt matcher.
 				"question": qn,
 				"domain":   qn,
 			}).Debug("Matched")
-			log.Debug("Finally use " + rcb.Name + " DNS")
+			log.Debugf("Finally use %s DNS", rcb.Name)
 			return true
 		}
 


### PR DESCRIPTION
This would make Overture use less memory on launch if there's a very big
config file that would be read.

Also some minor fixes to string handling