### PR TITLE
bug that reading the ip list text file when you configure the IPNeworkFile

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -270,7 +270,7 @@ func getIPNetworkList(file string) []*net.IPNet {
 		}
 
 		if line != "" {
-			_, ipNet, err := net.ParseCIDR(line)
+			_, ipNet, err := net.ParseCIDR(strings.TrimSuffix(line, "\n"))
 			if err != nil {
 				log.Errorf("Error parsing IP network CIDR %s: %s", line, err)
 				failures++


### PR DESCRIPTION
fix the read ip list txt bug. the bug error message as following:time="2019-07-28 01:39:07" level=error msg="Error parsing IP network CIDR 223.240.0.0/13\n: invalid CIDR address: 223.240.0.0/13\n". 
the bug come from the ReadString in bufio.NewRead will not trim the delimiter, so the "\n" still keep in line and make the CIDR parse throw error. 