### PR TITLE
fix #172

### DIFF
--- a/core/matcher/suffix/tree.go
+++ b/core/matcher/suffix/tree.go
@@ -62,6 +62,9 @@ func (dt *Tree) has(d Domain) bool {
 }
 
 func (dt *Tree) Has(d string) bool {
+	if len(dt.sub) == 0 {
+		return false
+	}
 	return dt.has(Domain(d))
 }
 


### PR DESCRIPTION
fix matcher always matched Primary DNS when matcher is suffix-tree and primary-domain-file is empty (#172)