### PR TITLE
Fix: respond if rejected, or the client hangs for the response

### DIFF
--- a/core/inbound/server.go
+++ b/core/inbound/server.go
@@ -128,6 +128,8 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, q *dns.Msg) {
 
 	for _, qt := range s.rejectQType {
 		if isQuestionType(q, qt) {
+			log.Debugf("Reject %s: %s", inboundIP, q.Question[0].String())
+			dns.HandleFailed(w, q)
 			return
 		}
 	}


### PR DESCRIPTION
If you rejected the query, you should let the client knows it, or the client may wait forever.