### PR TITLE
add final domain matcher

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/shawn1m/overture/core/matcher/mix"
 	"github.com/shawn1m/overture/core/matcher/regex"
 	"github.com/shawn1m/overture/core/matcher/suffix"
+	"github.com/shawn1m/overture/core/matcher/final"
 )
 
 type Config struct {
@@ -194,6 +195,8 @@ func getDomainMatcher(name string) (m matcher.Matcher) {
 		return &regex.List{}
 	case "mix-list":
 		return &mix.List{}
+	case "final":
+		return &final.Default{}
 	default:
 		log.Warnf("Matcher %s does not exist, using regex-list matcher as default", name)
 		return &regex.List{}

--- a/core/matcher/final/default.go
+++ b/core/matcher/final/default.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 shawn1m. All rights reserved.
+ * Use of this source code is governed by The MIT License (MIT) that can be
+ * found in the LICENSE file..
+ */
+
+package final
+
+type Default struct {
+}
+
+func (s *Default) Insert(str string) error {
+	return nil
+}
+
+func (s *Default) Has(str string) bool {
+	return true
+}
+
+func (s *Default) Name() string {
+	return "final"
+}


### PR DESCRIPTION
The final domain matcher always match all the rule. There is an example to use it.

Primary dns server match some domain, while alternative dns match others.

Then I can set primary DomainFile, and add final matcher for alternative dns. When dealing with an domain request that is not in primary DomainFile,   alternative dns will be choosen without ip match. 
If there is no final matcher, a dns request must be sent to get its ip. It's meaningless！