### PR TITLE
Final matcher

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -20,11 +20,11 @@ import (
 	"github.com/shawn1m/overture/core/common"
 	"github.com/shawn1m/overture/core/hosts"
 	"github.com/shawn1m/overture/core/matcher"
+	"github.com/shawn1m/overture/core/matcher/final"
 	"github.com/shawn1m/overture/core/matcher/full"
 	"github.com/shawn1m/overture/core/matcher/mix"
 	"github.com/shawn1m/overture/core/matcher/regex"
 	"github.com/shawn1m/overture/core/matcher/suffix"
-	"github.com/shawn1m/overture/core/matcher/final"
 )
 
 type Config struct {
@@ -39,9 +39,10 @@ type Config struct {
 		Alternative string
 	}
 	DomainFile struct {
-		Primary     string
-		Alternative string
-		Matcher     string
+		Primary            string
+		Alternative        string
+		PrimaryMatcher     string
+		AlternativeMatcher string
 	}
 	HostsFile     string
 	MinimumTTL    int
@@ -65,8 +66,8 @@ func NewConfig(configFile string) *Config {
 
 	config.DomainTTLMap = getDomainTTLMap(config.DomainTTLFile)
 
-	config.DomainPrimaryList = initDomainMatcher(config.DomainFile.Primary, config.DomainFile.Matcher)
-	config.DomainAlternativeList = initDomainMatcher(config.DomainFile.Alternative, config.DomainFile.Matcher)
+	config.DomainPrimaryList = initDomainMatcher(config.DomainFile.Primary, config.DomainFile.PrimaryMatcher)
+	config.DomainAlternativeList = initDomainMatcher(config.DomainFile.Alternative, config.DomainFile.AlternativeMatcher)
 
 	config.IPNetworkPrimaryList = getIPNetworkList(config.IPNetworkFile.Primary)
 	config.IPNetworkAlternativeList = getIPNetworkList(config.IPNetworkFile.Alternative)
@@ -205,7 +206,9 @@ func getDomainMatcher(name string) (m matcher.Matcher) {
 
 func initDomainMatcher(file string, name string) (m matcher.Matcher) {
 	m = getDomainMatcher(name)
-
+	if name == "final" {
+		return m
+	}
 	if file == "" {
 		return
 	}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 		Alternative        string
 		PrimaryMatcher     string
 		AlternativeMatcher string
+		Matcher            string
 	}
 	HostsFile     string
 	MinimumTTL    int
@@ -66,8 +67,8 @@ func NewConfig(configFile string) *Config {
 
 	config.DomainTTLMap = getDomainTTLMap(config.DomainTTLFile)
 
-	config.DomainPrimaryList = initDomainMatcher(config.DomainFile.Primary, config.DomainFile.PrimaryMatcher)
-	config.DomainAlternativeList = initDomainMatcher(config.DomainFile.Alternative, config.DomainFile.AlternativeMatcher)
+	config.DomainPrimaryList = initDomainMatcher(config.DomainFile.Primary, config.DomainFile.PrimaryMatcher, config.DomainFile.Matcher)
+	config.DomainAlternativeList = initDomainMatcher(config.DomainFile.Alternative, config.DomainFile.AlternativeMatcher, config.DomainFile.Matcher)
 
 	config.IPNetworkPrimaryList = getIPNetworkList(config.IPNetworkFile.Primary)
 	config.IPNetworkAlternativeList = getIPNetworkList(config.IPNetworkFile.Alternative)
@@ -204,7 +205,10 @@ func getDomainMatcher(name string) (m matcher.Matcher) {
 	}
 }
 
-func initDomainMatcher(file string, name string) (m matcher.Matcher) {
+func initDomainMatcher(file string, name string, defaultName string) (m matcher.Matcher) {
+	if name == "" {
+		name = defaultName
+	}
 	m = getDomainMatcher(name)
 	if name == "final" {
 		return m

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -24,6 +24,7 @@ import (
 	"github.com/shawn1m/overture/core/matcher/mix"
 	"github.com/shawn1m/overture/core/matcher/regex"
 	"github.com/shawn1m/overture/core/matcher/suffix"
+	"github.com/shawn1m/overture/core/matcher/final"
 )
 
 type Config struct {
@@ -194,6 +195,8 @@ func getDomainMatcher(name string) (m matcher.Matcher) {
 		return &regex.List{}
 	case "mix-list":
 		return &mix.List{}
+	case "final":
+		return &final.Default{}
 	default:
 		log.Warnf("Matcher %s does not exist, using regex-list matcher as default", name)
 		return &regex.List{}

--- a/core/matcher/final/default.go
+++ b/core/matcher/final/default.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2019 shawn1m. All rights reserved.
+ * Use of this source code is governed by The MIT License (MIT) that can be
+ * found in the LICENSE file..
+ */
+
+package final
+
+type Default struct {
+}
+
+func (s *Default) Insert(str string) error {
+	return nil
+}
+
+func (s *Default) Has(str string) bool {
+	return true
+}
+
+func (s *Default) Name() string {
+	return "final"
+}


### PR DESCRIPTION
1. separate primary matcher from alternative matcher. Old matcher config is used as default matcher name.
2. add final domain matcher that  always match all the rule

There is an example to use it.

Primary dns server match some domain, while alternative dns match others.Then I can set primary DomainFile, and add final matcher for alternative dns. 
```json
"DomainFile": {
      "Primary": "./domain_primary_sample",
      "Alternative": "",
      "PrimaryMatcher": "suffix-tree",
      "AlternativeMatcher":  "final"
    }
```

When dealing with an domain request that is not in primary DomainFile, alternative dns will be choosen without ip match.
If there is no final matcher, a dns request must be sent to get its ip. It's meaningless！