### PR TITLE
fix suffix tree

### DIFF
--- a/core/matcher/suffix/tree.go
+++ b/core/matcher/suffix/tree.go
@@ -14,8 +14,9 @@ import (
 type Domain string
 
 type Tree struct {
-	mark uint8
-	sub  domainMap
+	mark  uint8
+	sub   domainMap
+	final bool
 }
 
 func (dt *Tree) Name() string {
@@ -51,7 +52,7 @@ func NewDomainTree() (dt *Tree) {
 }
 
 func (dt *Tree) has(d Domain) bool {
-	if len(dt.sub) == 0 {
+	if len(dt.sub) == 0 || dt.final {
 		return true
 	}
 
@@ -71,6 +72,7 @@ func (dt *Tree) Has(d string) bool {
 func (dt *Tree) insert(sections []Domain) {
 
 	if len(sections) == 0 {
+		dt.final = true
 		return
 	}
 

--- a/core/matcher/suffix/tree_test.go
+++ b/core/matcher/suffix/tree_test.go
@@ -11,5 +11,24 @@ import (
 )
 
 func TestTree_Has(t *testing.T) {
-
+	tree := DefaultDomainTree()
+	for _, d := range []string{
+		"1.abc.com",
+		"2.abc.com",
+		"1.2.abc.com",
+	} {
+		tree.Insert(d)
+	}
+	for _, d := range []string{
+		"1.abc.com",
+		"2.abc.com",
+		"1.2.abc.com",
+	} {
+		if !tree.Has(d) {
+			t.Fail()
+		}
+	}
+	if tree.Has("abc.com") {
+		t.Fail()
+	}
 }


### PR DESCRIPTION
issue:
When insert abc.com and 1.abc.com, abc.com will not be matched.

Add an final flag to the tree to solve this problem.