### PR TITLE
Fix the domain matching method of the mix-list matcher.

### DIFF
--- a/core/matcher/mix/list.go
+++ b/core/matcher/mix/list.go
@@ -47,9 +47,12 @@ func (s *List) Has(str string) bool {
 		switch data.Type {
 		case "domain":
 			idx := len(str) - len(data.Content)
-			if idx > 0 && data.Content == str[idx:] {
-				return true
-			}
+			if idx >= 0 && data.Content == str[idx:] {
+                                if idx >=1 && (str[idx-1] != '.') {
+                                   return false
+                                }
+                                return true
+                        }
 		case "regex":
 			reg := regexp.MustCompile(data.Content)
 			if reg.MatchString(str) {


### PR DESCRIPTION
Currently, `domain:le.com` using `mix-list` method would cause `www.google.com` to match, which is unintended.
Also, currently the implementation causes `le.com` to fail matching `domain:le.com` as it is written as `idx>0`.

This fixes the aforementioned two issues.

Tested on my machine.